### PR TITLE
Prettierを導入しCSSファイルに適用

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+node_modules/
+dist/
+build/
+coverage/
+*.min.css
+*.min.js
+
+# CSS以外のファイルを無視
+*.js
+*.jsx
+*.ts
+*.tsx
+*.json
+*.md
+*.html
+*.yml
+*.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/blog.css
+++ b/blog.css
@@ -1,505 +1,514 @@
 /* <system section="theme" selected="wideboard"> */
-@import "/css/theme/wideboard/wideboard.css";
+@import '/css/theme/wideboard/wideboard.css';
 /* </system> */
 
 /* <system section="background" selected="fff"> */
 body {
-    background: #fff;
+  background: #fff;
 }
 
 /* </system> */
 
 html {
-    background: #fff;
+  background: #fff;
 }
 
 body {
-    background: #fff;
-    font-size: 18px;
-    font-family: 'Helvetica Neue', 'Helvetica', 'Univers', 'Arial', 'Hiragino Kaku Gothic Pro', 'Meiryo', 'MS PGothic', sans-serif;
+  background: #fff;
+  font-size: 18px;
+  font-family:
+    'Helvetica Neue', 'Helvetica', 'Univers', 'Arial',
+    'Hiragino Kaku Gothic Pro', 'Meiryo', 'MS PGothic', sans-serif;
 }
 
 #globalheader-container {
-    background: #fff;
+  background: #fff;
 }
 
 #blog-title-inner {
-    padding: 15px 20px 20px;
-    background: url(/css/theme/wideboard/header.png) no-repeat center top;
-    border-top: 1px solid #fff;
+  padding: 15px 20px 20px;
+  background: url(/css/theme/wideboard/header.png) no-repeat center top;
+  border-top: 1px solid #fff;
 }
 
 #top-editarea {
-    padding: 0 80px;
+  padding: 0 80px;
 }
 
 #box2 {
-    border-top: 1px solid #c9c9c3;
-    margin: 40px 0 0 0;
-    font-size: 14px;
+  border-top: 1px solid #c9c9c3;
+  margin: 40px 0 0 0;
+  font-size: 14px;
 }
 
 /* バナーを中央揃えに */
 #top-editarea-header-banner {
-    width: 728px;
-    margin: 10px auto 0px;
+  width: 728px;
+  margin: 10px auto 0px;
 }
 
 #content-inner {
-    margin: 40px auto;
-    max-width: 700px;
+  margin: 40px auto;
+  max-width: 700px;
 }
 
 /* entryのmargin調整 */
 .entry {
-    clear: both;
-    overflow: hidden;
-    position: relative;
-    margin: 0 0 40px 0;
+  clear: both;
+  overflow: hidden;
+  position: relative;
+  margin: 0 0 40px 0;
 }
 
 /* 文字サイズは大きめで */
 .entry-content p {
-    line-height: 1.8;
-    margin: 20px 0 0 0;
-    font-size: 18px;
+  line-height: 1.8;
+  margin: 20px 0 0 0;
+  font-size: 18px;
 }
 
 /* タイトル */
 .entry .entry-title a {
-    font-size: 28px;
-    margin: 0 0 10px 0;
-    display: inline-block;
-    font-weight: bold;
-    line-height: 23px;
-    line-height: 30px;
+  font-size: 28px;
+  margin: 0 0 10px 0;
+  display: inline-block;
+  font-weight: bold;
+  line-height: 23px;
+  line-height: 30px;
 }
 
 /* 見出しスタイル */
 .entry-content h3 {
-    font-weight: bold;
-    font-size: 25px;
-    padding: 0 0 5px 32px;
-    position: relative;
+  font-weight: bold;
+  font-size: 25px;
+  padding: 0 0 5px 32px;
+  position: relative;
 }
 
 .entry-content h3:before {
-    content: '';
-    display: block;
-    width: 22px;
-    height: 22px;
-    background: #666666;
-    float: left;
-    position: absolute;
-    top: 0;
-    left: 0;
-    padding-top: 2px;
+  content: '';
+  display: block;
+  width: 22px;
+  height: 22px;
+  background: #666666;
+  float: left;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding-top: 2px;
 }
 
 .entry-content h4 {
-    font-weight: bold;
-    font-size: 22px;
-    border-bottom: 1px solid #aaaaaa;
-    padding: 0 0 10px 0;
+  font-weight: bold;
+  font-size: 22px;
+  border-bottom: 1px solid #aaaaaa;
+  padding: 0 0 10px 0;
 }
 
 .entry-content h5 {
-    font-weight: bold;
-    font-size: 20px;
+  font-weight: bold;
+  font-size: 20px;
 }
 
 /* 見出しスタイル */
 
 /* 引用のスタイル */
 .entry-content blockquote {
-    padding: 20px 80px;
-    background: rgba(245, 245, 245, 0.8);
-    color: #222;
-    position: relative;
-    border: solid 1px #fff;
-    margin: 0.8em 0;
+  padding: 20px 80px;
+  background: rgba(245, 245, 245, 0.8);
+  color: #222;
+  position: relative;
+  border: solid 1px #fff;
+  margin: 0.8em 0;
 }
 
 .entry-content blockquote p {
-    font-size: 90%;
+  font-size: 90%;
 }
 
 .entry-content blockquote:before {
-    content: "“";
-    font-family: serif;
-    position: absolute;
-    top: 0;
-    left: 0;
-    font-size: 600%;
-    color: rgba(200, 200, 200, 1);
-    line-height: 1em;
+  content: '“';
+  font-family: serif;
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 600%;
+  color: rgba(200, 200, 200, 1);
+  line-height: 1em;
 }
 
 .entry-content blockquote:after {
-    content: "”";
-    font-family: serif;
-    position: absolute;
-    bottom: 0;
-    right: 30px;
-    font-size: 600%;
-    color: rgba(200, 200, 200, 1);
-    line-height: 0;
+  content: '”';
+  font-family: serif;
+  position: absolute;
+  bottom: 0;
+  right: 30px;
+  font-size: 600%;
+  color: rgba(200, 200, 200, 1);
+  line-height: 0;
 }
 
 .entry-content blockquote img {
-    max-width: 100%;
+  max-width: 100%;
 }
 
 .entry-content blockquote cite {
-    display: block;
-    text-align: right;
-    font-size: 80%;
+  display: block;
+  text-align: right;
+  font-size: 80%;
 }
 
 .entry-content blockquote p {
-    margin: 0;
+  margin: 0;
 }
 
 /* 引用のスタイル */
 
 /* 箇条書きのスタイル */
 .entry-content ol li {
-    list-style-type: decimal;
+  list-style-type: decimal;
 }
 
 /* 箇条書きのスタイル */
 
 /* ソースコードのスタイル */
 .entry-content pre.code {
-    font-size: 18px;
-    background-color: #073642;
-    color: #93a1a1;
+  font-size: 18px;
+  background-color: #073642;
+  color: #93a1a1;
 }
 
 .synSpecial {
-    color: #dc322f
+  color: #dc322f;
 }
 
 .synType {
-    color: #b58900
+  color: #b58900;
 }
 
 .synComment {
-    color: #657b83
+  color: #657b83;
 }
 
 .synPreProc {
-    color: #cb4b16
+  color: #cb4b16;
 }
 
 .synIdentifier {
-    color: #268bd2
+  color: #268bd2;
 }
 
 .synConstant {
-    color: #2aa198
+  color: #2aa198;
 }
 
 .synStatement {
-    color: #859900
+  color: #859900;
 }
 
 /* ソースコードのスタイル */
 
 /* Amazon貼り付けのスタイル */
 .entry-content .hatena-asin-detail-info {
-    max-width: 500px;
+  max-width: 500px;
 }
 
 /* btn系のスタイル */
 .btn {
-    display: inline-block;
-    *display: inline;
-    *zoom: 1;
-    padding: 4px 10px 4px;
-    margin-bottom: 0;
-    line-height: 18px;
-    color: #444 !important;
-    background-color: #f5f5f5;
-    text-align: center;
-    vertical-align: middle;
-    border: 1px solid #dddddd;
-    -webkit-border-top-right-radius: 2px;
-    -webkit-border-bottom-right-radius: 0;
-    -webkit-border-bottom-left-radius: 0;
-    -webkit-border-top-left-radius: 0;
-    -moz-border-radius-topright: 2px;
-    -moz-border-radius-bottomright: 0;
-    -moz-border-radius-bottomleft: 0;
-    -moz-border-radius-topleft: 0;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-    -moz-background-clip: padding;
-    -webkit-background-clip: padding-box;
-    background-clip: padding-box;
-    -webkit-border-radius: 2px;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
-    -moz-background-clip: padding;
-    -webkit-background-clip: padding-box;
-    background-clip: padding-box;
-    cursor: pointer;
-    font-size: 12px;
-    text-decoration: none;
-    font-weight: bold;
-    -webkit-appearance: none;
+  display: inline-block;
+  *display: inline;
+  *zoom: 1;
+  padding: 4px 10px 4px;
+  margin-bottom: 0;
+  line-height: 18px;
+  color: #444 !important;
+  background-color: #f5f5f5;
+  text-align: center;
+  vertical-align: middle;
+  border: 1px solid #dddddd;
+  -webkit-border-top-right-radius: 2px;
+  -webkit-border-bottom-right-radius: 0;
+  -webkit-border-bottom-left-radius: 0;
+  -webkit-border-top-left-radius: 0;
+  -moz-border-radius-topright: 2px;
+  -moz-border-radius-bottomright: 0;
+  -moz-border-radius-bottomleft: 0;
+  -moz-border-radius-topleft: 0;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding-box;
+  background-clip: padding-box;
+  -webkit-border-radius: 2px;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding-box;
+  background-clip: padding-box;
+  cursor: pointer;
+  font-size: 12px;
+  text-decoration: none;
+  font-weight: bold;
+  -webkit-appearance: none;
 }
 
 .btn:hover {
-    border-color: #ccc;
-    background-color: #eeeeee;
-    text-decoration: none !important;
+  border-color: #ccc;
+  background-color: #eeeeee;
+  text-decoration: none !important;
 }
 
 .btn-blue,
 .btn-primary {
-    color: #fff !important;
-    background: #14afd6;
-    border: 1px solid transparent;
+  color: #fff !important;
+  background: #14afd6;
+  border: 1px solid transparent;
 }
 
 .btn-blue:hover,
 .btn-primary:hover {
-    border-color: #129fc2;
-    background: #129fc2;
-    background: -webkit-gradient(linear, left top, left bottom, from(#14afd6), to(#129fc2));
-    background: -ms-linear-gradient(top, #14afd6, #129fc2);
-    background: -moz-linear-gradient(top, #14afd6 0%, #129fc2 100%);
+  border-color: #129fc2;
+  background: #129fc2;
+  background: -webkit-gradient(linear,
+      left top,
+      left bottom,
+      from(#14afd6),
+      to(#129fc2));
+  background: -ms-linear-gradient(top, #14afd6, #129fc2);
+  background: -moz-linear-gradient(top, #14afd6 0%, #129fc2 100%);
 }
 
 .btn-register {
-    color: #fff !important;
-    background: #1aba56;
-    border: 1px solid transparent;
+  color: #fff !important;
+  background: #1aba56;
+  border: 1px solid transparent;
 }
 
 .btn-register:hover {
-    background: #15a24a;
-    background: -webkit-gradient(linear, left top, left bottom, from(#1aba56), to(#15a24a));
-    background: -ms-linear-gradient(top, #1aba56, #15a24a);
-    background: -moz-linear-gradient(top, #1aba56 0%, #15a24a 100%);
-    border-color: #15a24a;
+  background: #15a24a;
+  background: -webkit-gradient(linear,
+      left top,
+      left bottom,
+      from(#1aba56),
+      to(#15a24a));
+  background: -ms-linear-gradient(top, #1aba56, #15a24a);
+  background: -moz-linear-gradient(top, #1aba56 0%, #15a24a 100%);
+  border-color: #15a24a;
 }
 
 .btn-small {
-    padding: 2px 10px !important;
-    font-size: 11px !important;
+  padding: 2px 10px !important;
+  font-size: 11px !important;
 }
 
 .btn-large {
-    padding: 13px 19px;
-    font-size: 17px;
-    line-height: normal;
-    font-weight: bold;
+  padding: 13px 19px;
+  font-size: 17px;
+  line-height: normal;
+  font-weight: bold;
 }
 
-.btn[disabled="disabled"],
-.btn[disabled="disabled"]:hover,
-input#submit[disabled="disabled"],
-input#submit[disabled="disabled"]:hover {
-    -moz-opacity: 0.4;
-    opacity: 0.4;
-    -khtml-opacity: 0.4;
-    -webkit-opacity: 0.4;
-    cursor: default;
-    white-space: nowrap;
+.btn[disabled='disabled'],
+.btn[disabled='disabled']:hover,
+input#submit[disabled='disabled'],
+input#submit[disabled='disabled']:hover {
+  -moz-opacity: 0.4;
+  opacity: 0.4;
+  -khtml-opacity: 0.4;
+  -webkit-opacity: 0.4;
+  cursor: default;
+  white-space: nowrap;
 }
 
 .btn.disabled,
 .btn.disabled:hover {
-    cursor: default;
-    background: #f5f5f5;
-    border-color: #ccc;
-    text-shadow: 0 -1px 0px rgba(0, 0, 0, 0.4);
-    -moz-text-shadow: 0 -1px 0px rgba(0, 0, 0, 0.4);
-    -webkit-text-shadow: 0 -1px 0px rgba(0, 0, 0, 0.4);
+  cursor: default;
+  background: #f5f5f5;
+  border-color: #ccc;
+  text-shadow: 0 -1px 0px rgba(0, 0, 0, 0.4);
+  -moz-text-shadow: 0 -1px 0px rgba(0, 0, 0, 0.4);
+  -webkit-text-shadow: 0 -1px 0px rgba(0, 0, 0, 0.4);
 }
 
 .btn-group .btn {
-    position: relative;
-    float: left;
-    margin-left: -1px;
-    -webkit-border-radius: 0;
-    -moz-border-radius: 0;
-    border-radius: 0;
+  position: relative;
+  float: left;
+  margin-left: -1px;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
 }
 
 .btn-group .btn:first-child {
-    margin-left: 0;
-    -webkit-border-top-left-radius: 4px;
-    -moz-border-radius-topleft: 4px;
-    border-top-left-radius: 4px;
-    -webkit-border-bottom-left-radius: 4px;
-    -moz-border-radius-bottomleft: 4px;
-    border-bottom-left-radius: 4px;
+  margin-left: 0;
+  -webkit-border-top-left-radius: 4px;
+  -moz-border-radius-topleft: 4px;
+  border-top-left-radius: 4px;
+  -webkit-border-bottom-left-radius: 4px;
+  -moz-border-radius-bottomleft: 4px;
+  border-bottom-left-radius: 4px;
 }
 
 .btn-group .btn:last-child,
 .btn-group .dropdown-toggle {
-    -webkit-border-top-right-radius: 4px;
-    -moz-border-radius-topright: 4px;
-    border-top-right-radius: 4px;
-    -webkit-border-bottom-right-radius: 4px;
-    -moz-border-radius-bottomright: 4px;
-    border-bottom-right-radius: 4px;
+  -webkit-border-top-right-radius: 4px;
+  -moz-border-radius-topright: 4px;
+  border-top-right-radius: 4px;
+  -webkit-border-bottom-right-radius: 4px;
+  -moz-border-radius-bottomright: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .btn-group .btn.large:first-child {
-    margin-left: 0;
-    -webkit-border-top-left-radius: 6px;
-    -moz-border-radius-topleft: 6px;
-    border-top-left-radius: 6px;
-    -webkit-border-bottom-left-radius: 6px;
-    -moz-border-radius-bottomleft: 6px;
-    border-bottom-left-radius: 6px;
+  margin-left: 0;
+  -webkit-border-top-left-radius: 6px;
+  -moz-border-radius-topleft: 6px;
+  border-top-left-radius: 6px;
+  -webkit-border-bottom-left-radius: 6px;
+  -moz-border-radius-bottomleft: 6px;
+  border-bottom-left-radius: 6px;
 }
 
 .btn-group .btn.large:last-child,
 .btn-group .large.dropdown-toggle {
-    -webkit-border-top-right-radius: 6px;
-    -moz-border-radius-topright: 6px;
-    border-top-right-radius: 6px;
-    -webkit-border-bottom-right-radius: 6px;
-    -moz-border-radius-bottomright: 6px;
-    border-bottom-right-radius: 6px;
+  -webkit-border-top-right-radius: 6px;
+  -moz-border-radius-topright: 6px;
+  border-top-right-radius: 6px;
+  -webkit-border-bottom-right-radius: 6px;
+  -moz-border-radius-bottomright: 6px;
+  border-bottom-right-radius: 6px;
 }
 
 .btn-group .btn:hover,
 .btn-group .btn:focus,
 .btn-group .btn:active,
 .btn-group .btn.active {
-    z-index: 2;
+  z-index: 2;
 }
 
 .btn-group .dropdown-toggle:active,
 .btn-group.open .dropdown-toggle {
-    outline: 0;
+  outline: 0;
 }
 
 .hatena-module {
-    width: 320px;
-    float: left;
-    margin: 10px 5px 20px 0;
-    min-height: 220px;
+  width: 320px;
+  float: left;
+  margin: 10px 5px 20px 0;
+  min-height: 220px;
 }
 
-.hatena-module:nth-child(2n+1) {
-    clear: left;
+.hatena-module:nth-child(2n + 1) {
+  clear: left;
 }
 
 /* スターのコンテナの右にソーシャルパーツが出てしまう問題対処 */
 .hatena-star-container {
-    float: none;
+  float: none;
 }
 
 /* 記事下のおすすめ本widget */
 .episode-footer-widget {
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .episode-footer-widget .widget-item {
-    display: block;
-    *zoom: 1;
-    /* width: 30%; */
-    /* float: left; */
-    font-size: 0.8em;
-    list-style: none;
-    padding-bottom: 0.7em;
-    margin-bottom: 0.7em;
-    border-bottom: 1px solid #d5d5d5;
+  display: block;
+  *zoom: 1;
+  /* width: 30%; */
+  /* float: left; */
+  font-size: 0.8em;
+  list-style: none;
+  padding-bottom: 0.7em;
+  margin-bottom: 0.7em;
+  border-bottom: 1px solid #d5d5d5;
 }
 
 .episode-footer-widget .widget-item:after {
-    display: block;
-    visibility: hidden;
-    font-size: 0;
-    height: 0;
-    clear: both;
-    content: ".";
+  display: block;
+  visibility: hidden;
+  font-size: 0;
+  height: 0;
+  clear: both;
+  content: '.';
 }
 
 .episode-footer-widget .widget-item .widget-item-label {
-    margin: 0 0 0.3em;
+  margin: 0 0 0.3em;
 }
 
 .episode-footer-widget .widget-item .widget-item-label a {
-    color: #4048af;
-    border-bottom: 1px solid #4048af;
+  color: #4048af;
+  border-bottom: 1px solid #4048af;
 }
 
 .episode-footer-widget .widget-item .widget-item-img {
-    margin: 0 10px 0 0;
-    float: left;
-    width: 80px;
+  margin: 0 10px 0 0;
+  float: left;
+  width: 80px;
 }
 
 .episode-footer-widget .widget-item .widget-item-img img {
-    max-width: 100%;
+  max-width: 100%;
 }
-
 
 /* おすすめ本widget */
 .footer-widget {
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .footer-widget .widget-item {
-    display: block;
-    *zoom: 1;
-    list-style: none;
-    padding-bottom: 0.7em;
-    margin-bottom: 0.7em;
-    border-bottom: 1px solid #d5d5d5;
+  display: block;
+  *zoom: 1;
+  list-style: none;
+  padding-bottom: 0.7em;
+  margin-bottom: 0.7em;
+  border-bottom: 1px solid #d5d5d5;
 }
 
 .footer-widget .widget-item:after {
-    display: block;
-    visibility: hidden;
-    font-size: 0;
-    height: 0;
-    clear: both;
-    content: ".";
+  display: block;
+  visibility: hidden;
+  font-size: 0;
+  height: 0;
+  clear: both;
+  content: '.';
 }
 
 .footer-widget .widget-item .widget-item-label {
-    margin: 0 0 0.3em;
+  margin: 0 0 0.3em;
 }
 
 .footer-widget .widget-item .widget-item-label a {
-    color: #4048af;
-    border-bottom: 1px solid #4048af;
+  color: #4048af;
+  border-bottom: 1px solid #4048af;
 }
 
 .footer-widget .widget-item .widget-item-img {
-    margin: 0 10px 0 0;
-    float: left;
-    width: 80px;
+  margin: 0 10px 0 0;
+  float: left;
+  width: 80px;
 }
 
 .footer-widget .widget-item .widget-item-img img {
-    max-width: 100%;
+  max-width: 100%;
 }
 
 /* 目次 */
 .table-of-contents {
-    padding: 15px 10px 15px 35px;
-    font-size: 100%;
-    border: dotted 1px #777;
-    background: #f7f7f7;
+  padding: 15px 10px 15px 35px;
+  font-size: 100%;
+  border: dotted 1px #777;
+  background: #f7f7f7;
 }
 
 .table-of-contents:before {
-    content: "目次";
-    font-size: 120%;
-    color: #000;
-    margin: -5px 0px 10px -20px;
+  content: '目次';
+  font-size: 120%;
+  color: #000;
+  margin: -5px 0px 10px -20px;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "textlint-rule-preset-ja-spacing": "^2.4.3",
         "textlint-rule-preset-ja-technical-writing": "^12.0.2",
         "textlint-rule-spellcheck-tech-word": "^5.0.0"
+      },
+      "devDependencies": {
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@azu/format-text": {
@@ -3465,6 +3468,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prh": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "author": "shibayu36 <shibayu36@gmail.com> (https://github.com/shibayu36)",
   "license": "MIT",
@@ -14,5 +16,8 @@
     "textlint-rule-preset-ja-spacing": "^2.4.3",
     "textlint-rule-preset-ja-technical-writing": "^12.0.2",
     "textlint-rule-spellcheck-tech-word": "^5.0.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- Prettierを導入し、CSSファイルのコードスタイルを自動的に統一できるようにしました
- 初回フォーマットとしてblog.cssを整形しました

## 変更内容
- **Prettier v3.6.2**をdevDependenciesに追加
- **.prettierrc**で基本的な設定を定義（インデント2スペース、シングルクォート等）
- **.prettierignore**でCSS以外のファイルを除外設定
- **npm script**に`format`と`format:check`コマンドを追加
- **blog.css**を初回フォーマット

## 使い方
```bash
# CSSファイルをフォーマット
npm run format

# フォーマットが必要かチェック（変更なし）
npm run format:check
```

## Test plan
- [x] `npm run format:check`でCSSファイルのチェックが動作することを確認
- [x] `npm run format`でCSSファイルがフォーマットされることを確認
- [x] CSS以外のファイル（.md, .js等）がフォーマット対象外であることを確認