### PR TITLE
feat: デスクトップ版ブログにプロフィールアイコンを追加

### DIFF
--- a/blog.css
+++ b/blog.css
@@ -35,6 +35,11 @@ body {
   border-top: 1px solid #fff;
 }
 
+#blog-title-inner #title,
+#blog-title-inner #blog-description {
+  text-align: left;
+}
+
 #blog-title-inner::before {
   content: '';
   display: block;

--- a/blog.css
+++ b/blog.css
@@ -26,9 +26,27 @@ body {
 }
 
 #blog-title-inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
   padding: 15px 20px 20px;
   background: url(/css/theme/wideboard/header.png) no-repeat center top;
   border-top: 1px solid #fff;
+}
+
+#blog-title-inner::before {
+  content: '';
+  display: block;
+  width: 60px;
+  height: 60px;
+  background-image: url('https://cdn.user.blog.st-hatena.com/custom_blog_icon/25275191/1514233426688296');
+  background-size: cover;
+  background-position: center;
+  border-radius: 50%;
+  border: 3px solid #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  flex-shrink: 0;
 }
 
 #top-editarea {
@@ -512,3 +530,4 @@ input#submit[disabled='disabled']:hover {
   color: #000;
   margin: -5px 0px 10px -20px;
 }
+


### PR DESCRIPTION
## Summary
- ブログのデスクトップ版でタイトルとサブタイトルの横にプロフィールアイコンを表示
- モバイル版と同様のデザインに統一

## 変更内容
- `#blog-title-inner`をflexboxレイアウトに変更
- プロフィールアイコンを60pxサイズで表示（円形、白枠、影付き）
- タイトルとサブタイトルを左揃えに変更
- 画面幅が狭くなってもレイアウトが崩れないよう対応

## Test plan
- [ ] デスクトップ版でプロフィールアイコンが正しく表示される
- [ ] タイトルとサブタイトルが左揃えで表示される
- [ ] 画面幅を狭めてもレイアウトが崩れない
- [ ] モバイル版との一貫性が保たれている